### PR TITLE
add[Settings/JVM]: Add switch to revert to old "Execute a .jar" behaviour

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
@@ -1,5 +1,7 @@
 package net.kdt.pojavlaunch;
 
+import static net.kdt.pojavlaunch.prefs.LauncherPreferences.DEFAULT_PREF;
+
 import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.ClipboardManager;
@@ -242,8 +244,8 @@ public class JavaGUILauncherActivity extends BaseActivity implements View.OnTouc
                 selectedMod = findModPath(argList);
             }
             Runtime selectedRuntime;
-            if(selectedMod == null) {
-                // We were unable to find out the path to the mod. In that case, use the default runtime.
+            if(selectedMod == null || DEFAULT_PREF.getBoolean("disable_autojre_select", false)) {
+                // If we are unable to find out the path to the mod or the user explicitly desires so, we use the default runtime
                 selectedRuntime = MultiRTUtils.forceReread(LauncherPreferences.PREF_DEFAULT_RUNTIME);
             }else {
                 // Autoselect it properly in the other case.

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceJavaFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceJavaFragment.java
@@ -7,7 +7,10 @@ import android.os.Bundle;
 import android.widget.TextView;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.annotation.Nullable;
 import androidx.preference.EditTextPreference;
+import androidx.preference.Preference;
+import androidx.preference.SwitchPreference;
 
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.Tools;
@@ -18,10 +21,19 @@ import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 
 public class LauncherPreferenceJavaFragment extends LauncherPreferenceFragment {
     private MultiRTConfigDialog mDialogScreen;
+    private SwitchPreference mSwitchAutoJRE;
     private final ActivityResultLauncher<Object> mVmInstallLauncher =
             registerForActivityResult(new OpenDocumentWithExtension("xz"), (data)->{
                 if(data != null) Tools.installRuntimeFromUri(getContext(), data);
             });
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mSwitchAutoJRE = findPreference("disable_autojre_select");
+        mSwitchAutoJRE.setSummary("Stops automatic selection of which runtime to use in \"" + getString(R.string.main_install_jar_file) + "\"");
+
+    }
 
     @Override
     public void onCreatePreferences(Bundle b, String str) {

--- a/app_pojavlauncher/src/main/res/xml/pref_java.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_java.xml
@@ -30,6 +30,12 @@
             app2:selectable="false"/>
 
         <SwitchPreference
+            android:defaultValue="false"
+            android:key="disable_autojre_select"
+            android:title="Disable automatic JRE selection"
+            />
+
+        <SwitchPreference
             android:defaultValue="true"
             android:key="java_sandbox"
             android:summary="@string/mcl_setting_java_sandbox_subtitle"


### PR DESCRIPTION
Some edge cases, like jars that try to gracefully handle users using the wrong Java version with a Swing pop-up, cause the Java version detection to give the wrong result because the pop-up is made for Java 8.

This adds a switch to override that behaviour with the old one, from before https://github.com/AngelAuraMC/Amethyst-Android/commit/3b1ad643427a21fea527e7252764f3c94d97c973, which simply used the default runtime selected by the user.