### PR TITLE
fix[version_list]: Move file to cache

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/AsyncVersionList.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/AsyncVersionList.java
@@ -26,7 +26,7 @@ public class AsyncVersionList {
 
     public void getVersionList(@Nullable VersionDoneListener listener, boolean secondPass){
         sExecutorService.execute(() -> {
-            File versionFile = new File(Tools.DIR_DATA + "/version_list.json");
+            File versionFile = new File(Tools.DIR_CACHE + "/version_list.json");
             JMinecraftVersionList versionList = null;
             try{
                 if(!versionFile.exists() || (System.currentTimeMillis() > versionFile.lastModified() + 86400000 )){
@@ -68,7 +68,7 @@ public class AsyncVersionList {
 
             // Then save the version list
             //TODO make it not save at times ?
-            FileOutputStream fos = new FileOutputStream(Tools.DIR_DATA + "/version_list.json");
+            FileOutputStream fos = new FileOutputStream(Tools.DIR_CACHE + "/version_list.json");
             fos.write(jsonString.getBytes());
             fos.close();
 


### PR DESCRIPTION
This allows people to forcibly reset it to see newer version faster by clearing the cache. Plus if you don't have internet, having this isn't even important.