### PR TITLE
fix(Renderer/Default): Check asset ID instead of mcver

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -926,7 +926,7 @@ public final class Tools {
                 insertSafety(inheritsVer, customVer,
                         "assetIndex", "assets", "id",
                         "mainClass", "minecraftArguments",
-                        "releaseTime", "time", "type"
+                        "releaseTime", "time", "type", "inheritsFrom"
                 );
 
                 // Go through the libraries, remove the ones overridden by the custom version

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -469,4 +469,5 @@
     <string name="preference_force_enable_touchcontroller_description">Force enable TouchController integration, even if mod file is not found.</string>
     <string name="preference_touchcontroller_vibrate_length_title">TouchController vibrate length</string>
     <string name="preference_touchcontroller_vibrate_length_description">Set the length of the vibration when using TouchController.</string>
+    <string name="error_vanilla_json_corrupt">Vanilla json seems to be corrupt. Please send a bug report on github or discord.</string>
 </resources>


### PR DESCRIPTION
This is now based on the assetIndex.id that mojangs jsons have. I am
assuming inheritedFrom to always be present, if it isn't it'll treat it
like vanilla but it should still work due to the insertSafety setting
that field

This fixes the code breaking on versions with letters in them

Please finally don't break