### PR TITLE
fix(GLFW): Fixx NullPtr when using zink without turnip

### DIFF
--- a/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
+++ b/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
@@ -1005,7 +1005,9 @@ public class GLFW
         // These values can be found at headings_array.xml
         switch (System.getenv("POJAV_RENDERER")) {
             case "vulkan_zink":
-                if (System.getenv("POJAV_LOAD_TURNIP").equals("1")) {
+                Boolean turnipLoad = System.getenv("POJAV_LOAD_TURNIP") != null ?
+                    System.getenv("POJAV_LOAD_TURNIP").equals("1") : false;
+                if (turnipLoad) {
                     System.out.println("GLFW: Turnip+Zink detected, setting GL context to 4.6");
                     glMajor = 4;
                     glMinor = 6;


### PR DESCRIPTION
The fix in #46 causes a crash when using zink without turnip