### PR TITLE
[REGRESSION] fix: tab completion breaking in 1.8.9

### DIFF
--- a/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
+++ b/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
@@ -70,13 +70,19 @@ public class CallbackBridge {
     public static void sendKeycode(int keycode, char keychar, int scancode, int modifiers, boolean isDown) {
         // TODO CHECK: This may cause input issue, not receive input!
         if(keycode != 0)  nativeSendKey(keycode,scancode,isDown ? 1 : 0, modifiers);
-        if(isDown && keychar != '\u0000') {
+        // Only controlmaps goes through here, that means we need to block ISOControl or else
+        // Minecraft tries to type :TAB: as a character in chat, fails, and then ignores the key,
+        // breaking the tab autofill function in old versions. (like 1.12.2, 1.8.9).
+        if(isDown && !Character.isISOControl(keychar)) {
             nativeSendCharMods(keychar,modifiers);
             nativeSendChar(keychar);
         }
     }
 
     public static void sendChar(char keychar, int modifiers){
+        // Only an EditText goes through here, that means emojis are allowed, so no isISOControl
+        // cause we might break emoji mods then.
+        // See net/kdt/pojavlaunch/customcontrols/keyboard/TouchCharInput.java#L147 (onTextChanged)
         nativeSendCharMods(keychar,modifiers);
         nativeSendChar(keychar);
     }


### PR DESCRIPTION
The typable controlmaps PR triggered old incorrect logic to break, that is now fixed and documented

It broke because all controlmap inputs sent no characters, now they do, and the only filter they had against sending non-character codepoints was checking if the codepoint was null, which it always was, because they never sent any.

Now we check if its actually a non-character codepoint.