### PR TITLE
fix: Legacy4J GLFW controller enable

### DIFF
--- a/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
+++ b/jre_lwjgl3glfw/src/main/java/org/lwjgl/glfw/GLFW.java
@@ -1269,8 +1269,10 @@ public class GLFW
         }else return null;
     }
     public static boolean glfwJoystickIsGamepad(int jid) {
-        if(jid == GLFW_JOYSTICK_1) return true;
-        else return false;
+        if(jid == GLFW_JOYSTICK_1) {
+            CallbackBridge.enableGamepadDirectInput();
+            return true;
+        }else return false;
     }
     public static String glfwGetJoystickGUID(int jid) {
         // Return Xbox 360 controller GUID


### PR DESCRIPTION
Legacy4J previously was not being detected by the GLFW implementation as a mod that was using GLFW controllers, thus leading it to use vanilla keyboard+mouse emulation. This fixes that.

This is still kinda bugged on L4J settings menu but this only applies when outside of a world. I can't figure out why L4J does this only on their menus, I probably wont either, SDL doesn't have this.