### PR TITLE
[Regression]fix: Legacy Fabric using wrong LWJGL classes

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -363,7 +363,11 @@ public final class Tools {
 
         javaArgList.addAll(Arrays.asList(getMinecraftJVMArgs(versionId, gamedir)));
         javaArgList.add("-cp");
-        javaArgList.add(launchClassPath + ":" + getLWJGL3ClassPath());
+        if (launchClassPath.contains("bta-client-")){ // BTADownloadTask.BASE_JSON sets this. Jank.
+            // BTA for some reason needs this to be last or else it uses the wrong lwjgl
+            javaArgList.add(launchClassPath + ":" + getLWJGL3ClassPath());
+        // Legacy Fabric needs this to be first or else it uses the wrong lwjgl
+        } else javaArgList.add(getLWJGL3ClassPath() + ":" + launchClassPath);
 
         javaArgList.add(versionInfo.mainClass);
         javaArgList.addAll(Arrays.asList(launchArgs));


### PR DESCRIPTION
https://github.com/AngelAuraMC/Amethyst-Android/commit/4903cfc8d3afd63918f59caf0a146efc2d837069 broke Legacy Fabric in that it ignored the set classpath and used their shipped LWJGL 2.9.4 which tried to  `System.loadLibrary(lwjgl-linux-aarch64)` and died since that doesn't exist here.

This commit just turns that change into something that only applies to BTA