### PR TITLE
Fix SDL joystick inputs

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -236,7 +236,14 @@ public class MinecraftGLSurface extends View implements GrabListener, DirectGame
     @SuppressLint("NewApi")
     @Override
     public boolean dispatchGenericMotionEvent(MotionEvent event) {
-        if (MainActivity.motionListener.onGenericMotion(this, event)) return true;
+        if(sdlEnabled && Gamepad.isGamepadEvent(event)) {
+            try {
+                MainActivity.motionListener.onGenericMotion(this, event);
+                return true;
+            } catch (Throwable ignored){
+                Log.e(TAG, "SDL failed to send motionevent!");
+            }
+        }
         super.dispatchGenericMotionEvent(event);
         int mouseCursorIndex = -1;
 
@@ -317,7 +324,7 @@ public class MinecraftGLSurface extends View implements GrabListener, DirectGame
         if (sdlEnabled && isGamepadEvent) {
                 try {
                     SDLActivity.handleKeyEvent(this, eventKeycode, event, null);
-                    if (isGamepadEvent) return true;
+                    return true;
                 } catch (Throwable ignored){
                     Log.e(TAG, "SDL failed to send keyevent!");
                 }


### PR DESCRIPTION
The not gamepad input detection shortcut I tried to pull turned out to be VERY WRONG. This is the proper way and how blocking all non-keyboard keyevents also works.