### PR TITLE
fix: 1.6.4 crash

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -390,24 +390,29 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
     private void runCraft(String versionId, JMinecraftVersionList.Version version) throws Throwable {
         String assetVersion;
-        if (version.inheritsFrom != null) { // We are almost definitely modded if this runs
-            File vanillaJsonFile = new File(Tools.DIR_HOME_VERSION + "/" + version.inheritsFrom + "/" + version.inheritsFrom + ".json");
-            JMinecraftVersionList.Version vanillaJson;
-            try { // Get the vanilla json from modded instance
-                vanillaJson = Tools.GLOBAL_GSON.fromJson(Tools.read(vanillaJsonFile.getAbsolutePath()), JMinecraftVersionList.Version.class);
-            } catch (IOException ignored) { // Should never happen, we check for this in MinecraftDownloader().start()
-                throw new RuntimeException(getString(R.string.error_vanilla_json_corrupt));
+        try {
+            if (version.inheritsFrom != null) { // We are almost definitely modded if this runs
+                File vanillaJsonFile = new File(Tools.DIR_HOME_VERSION + "/" + version.inheritsFrom + "/" + version.inheritsFrom + ".json");
+                JMinecraftVersionList.Version vanillaJson;
+                try { // Get the vanilla json from modded instance
+                    vanillaJson = Tools.GLOBAL_GSON.fromJson(Tools.read(vanillaJsonFile.getAbsolutePath()), JMinecraftVersionList.Version.class);
+                } catch (IOException ignored) { // Should never happen, we check for this in MinecraftDownloader().start()
+                    throw new RuntimeException(getString(R.string.error_vanilla_json_corrupt));
+                }
+                // Something went wrong if this is somehow not the case anymore
+                if (!Objects.equals(vanillaJson.assets, vanillaJson.assetIndex.id))
+                    Tools.showErrorRemote(new RuntimeException(getString(R.string.error_vanilla_json_corrupt)));
+                assetVersion = vanillaJson.assets;
+            } else {
+                // Else assume we are vanilla
+                if (!Objects.equals(version.assets, version.assetIndex.id))
+                    Tools.showErrorRemote(new RuntimeException(getString(R.string.error_vanilla_json_corrupt)));
+                assetVersion = version.assets;
             }
-            // Something went wrong if this is somehow not the case anymore
-            if (!Objects.equals(vanillaJson.assets, vanillaJson.assetIndex.id))
-                Tools.showErrorRemote(new RuntimeException(getString(R.string.error_vanilla_json_corrupt)));
-            assetVersion = vanillaJson.assets;
-        } else {
-            // Else assume we are vanilla
-            if (!Objects.equals(version.assets, version.assetIndex.id))
-                Tools.showErrorRemote(new RuntimeException(getString(R.string.error_vanilla_json_corrupt)));
-            assetVersion = version.assets;
-        }
+       } catch (RuntimeException ignored){
+            runOnUiThread(() -> Toast.makeText(this, R.string.autorendererselectfailed, Toast.LENGTH_LONG).show());
+            assetVersion = "legacy";
+       } // If this fails.. oh well.
         // Autoselect renderer
         if (Tools.LOCAL_RENDERER == null) {
             // 25w09a is when HolyGL4ES starts showing a black screen upon world load.

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -374,6 +374,12 @@ public final class Tools {
         // Legacy Fabric needs this to be first or else it uses the wrong lwjgl
         } else javaArgList.add(getLWJGL3ClassPath() + ":" + launchClassPath);
 
+        // Forge 1.6.4 crash mitigation
+        // https://github.com/MinecraftForge/FML/blob/f1b3381e61fac1a0ae90f521223c6bc613eb4888/common/cpw/mods/fml/common/asm/FMLSanityChecker.java#L192-L208
+        // It for some reason fails certification and crashes because it thinks Minecraft is corrupted.
+        // This also has no loading screen as a result.
+        javaArgList.add("-Dfml.ignoreInvalidMinecraftCertificates=true");
+
         javaArgList.add(versionInfo.mainClass);
         javaArgList.addAll(Arrays.asList(launchArgs));
         // ctx.appendlnToLog("full args: "+javaArgList.toString());

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -482,4 +482,5 @@
     <string name="oldL4JFound">You are using a version of Legacy4J without the android fixes! You will need to manually enable SDL in the controller settings to get the best experience!</string>
     <string name="global_warning">Warning!</string>
     <string name="controllableFound">Controllable currently has a random chance of crashing on launch. Either keep trying again and hope it launches or use another mod like Controlify.</string>
+    <string name="autorendererselectfailed">Auto-renderer select failed, defaulting to HolyGL4ES</string>
 </resources>


### PR DESCRIPTION
Because of old old forge not having `inheritsFrom` in the json, the renderer autoselector crashes

In addition to that, it crashes itself because it thinks the minecraft.jar is corrupted because it cant find the class that makes the loading screen appear. I can't figure out why it can't do this since i checksummed everything and it all checks out. All I can assume is this has something to do with the JRE.