### PR TITLE
fix: MinecraftGLSurface being auto set to wrong refreshrate

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -14,6 +14,7 @@ import android.graphics.SurfaceTexture;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.Display;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -413,6 +414,14 @@ public class MinecraftGLSurface extends View implements GrabListener, DirectGame
         // Initial size set. Request immedate refresh, otherwise the initial width and height for the game
         // may be broken/unknown.
         refreshSize(true);
+        // Ensures we run at correct refresh rate (should also NOT change the resolution being used)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            float maxHz = 120f; // Set to 120 by default just to be safe
+            for (float altHz : getDisplay().getMode().getAlternativeRefreshRates()) {
+                maxHz = Math.max(maxHz, altHz);
+            }
+            surface.setFrameRate(maxHz, Surface.FRAME_RATE_COMPATIBILITY_DEFAULT, Surface.CHANGE_FRAME_RATE_ONLY_IF_SEAMLESS);
+        }
 
         //Load Minecraft options:
         MCOptionUtils.set("fullscreen", "off");


### PR DESCRIPTION
This causes issues for phones that only have an option to make high refreshrate available, not forced (ie. Pixel)

Without setting this, it causes it to use 60hz, while the MinecraftGLSurface is at the hz the device runs at, which causes judder as they are desynced