### PR TITLE
fix: Don't run SDL's JNI on RenderThread

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -237,12 +237,16 @@ public class MinecraftGLSurface extends View implements GrabListener, DirectGame
     @Override
     public boolean dispatchGenericMotionEvent(MotionEvent event) {
         if(sdlEnabled && Gamepad.isGamepadEvent(event)) {
-            try {
-                MainActivity.motionListener.onGenericMotion(this, event);
-                return true;
-            } catch (Throwable ignored){
-                Log.e(TAG, "SDL failed to send motionevent!");
-            }
+            final MotionEvent copy = MotionEvent.obtain(event);
+            PojavApplication.sExecutorService.execute(()->{
+                try {
+                    MainActivity.motionListener.onGenericMotion(this, copy);
+                    copy.recycle();
+                } catch (Throwable ignored) {
+                    Log.e(TAG, "SDL failed to send motionevent!");
+                }
+            });
+            return true;
         }
         super.dispatchGenericMotionEvent(event);
         int mouseCursorIndex = -1;
@@ -322,13 +326,16 @@ public class MinecraftGLSurface extends View implements GrabListener, DirectGame
         // that don't have controller code so we are, checking for em.
         boolean isGamepadEvent = Gamepad.isGamepadEvent(event);
         if (sdlEnabled && isGamepadEvent) {
+            final KeyEvent copy = new KeyEvent(event);
+            PojavApplication.sExecutorService.execute(() -> {
                 try {
-                    SDLActivity.handleKeyEvent(this, eventKeycode, event, null);
-                    return true;
-                } catch (Throwable ignored){
+                    SDLActivity.handleKeyEvent(this, eventKeycode, copy, null);
+                } catch (Throwable ignored) {
                     Log.e(TAG, "SDL failed to send keyevent!");
                 }
-            }
+            });
+            return true;
+        }
         if(!sdlEnabled && isGamepadEvent){
             if(mGamepadHandler == null) createGamepad(this, event.getDevice());
 


### PR DESCRIPTION
I completely missed this, my bad

I don't know how to profile whether or not the keyevent running on another thread does much of anything. Should be an improvement though.

It does 100℅ improve analog input, no more renderthread dying cause of sdl jni'ing all over