### PR TITLE
fix: Grab JRE from any completed run

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           workflow: build.yml
           path: app_pojavlauncher/src/main/assets/components/jre
-          workflow_conclusion: success
+          workflow_conclusion: completed
           repo: AngelAuraMC/angelauramc-openjdk-build
           branch: buildjre8
           name: jre8-pojav
@@ -43,7 +43,7 @@ jobs:
         with:
           workflow: build.yml
           path: app_pojavlauncher/src/main/assets/components/jre-new
-          workflow_conclusion: success
+          workflow_conclusion: completed
           repo: AngelAuraMC/angelauramc-openjdk-build
           branch: buildjre17-21
           name: jre17-pojav
@@ -53,7 +53,7 @@ jobs:
         with:
           workflow: build.yml
           path: app_pojavlauncher/src/main/assets/components/jre-21
-          workflow_conclusion: success
+          workflow_conclusion: completed
           repo: AngelAuraMC/angelauramc-openjdk-build
           branch: buildjre17-21
           name: jre21-pojav


### PR DESCRIPTION
This stops it from failing if we only have cancelled or errored runs but still have android jre artifacts