### PR TITLE
bump(MobileGlues): 1.3.2 to 1.3.4 

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -239,12 +239,10 @@ public class LauncherPreferences {
         MGConfigJson.put("fsr1Setting", Integer.parseInt(DEFAULT_PREF.getString("mg_renderer_setting_fsr", "0")));
 
         // These guys are SwitchPreferences so they get special treatment, they need to be converted to ints
-        int gl43exts = DEFAULT_PREF.getBoolean("mg_renderer_setting_gl43ext", false) ? 1 : 0;
         int computeShaderext = DEFAULT_PREF.getBoolean("mg_renderer_computeShaderext", false) ? 1 : 0;
         int angleDepthClearFixMode = DEFAULT_PREF.getBoolean("mg_renderer_setting_angleDepthClearFixMode", false) ? 1 : 0;
         int timerQueryExt = DEFAULT_PREF.getBoolean("mg_renderer_setting_timerQueryExt", false) ? 1 : 0;
         int dsaExt = DEFAULT_PREF.getBoolean("mg_renderer_dsaExt", false) ? 1 : 0;
-        MGConfigJson.put("enableExtGL43", gl43exts);
         MGConfigJson.put("enableExtComputeShader", computeShaderext);
         MGConfigJson.put("angleDepthClearFixMode", angleDepthClearFixMode);
         MGConfigJson.put("enableExtTimerQuery", timerQueryExt);

--- a/app_pojavlauncher/src/main/res/xml/pref_renderer.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_renderer.xml
@@ -52,11 +52,6 @@
         </PreferenceCategory>
         <PreferenceCategory android:title="@string/preference_experimental_title">
             <SwitchPreference
-                android:title="@string/mg_renderer_title_gl43exts"
-                android:summary="@string/mg_renderer_summary_gl43exts"
-                android:key="mg_renderer_setting_gl43exts"
-                android:defaultValue="false" />
-            <SwitchPreference
                 android:title="@string/mg_renderer_title_computeShaderext"
                 android:summary="@string/mg_renderer_summary_computeShaderext"
                 android:key="mg_renderer_computeShaderext"


### PR DESCRIPTION
# Changes
- Removed GL43 option as MobileGlues also removed that. [It is functionally equivalent to `ARB_compute_shader`](https://github.com/MobileGL-Dev/MobileGlues-release/releases/tag/V1.3.4)