### PR TITLE
feat(TouchController): add IME padding support

### DIFF
--- a/app_pojavlauncher/src/main/AndroidManifest.xml
+++ b/app_pojavlauncher/src/main/AndroidManifest.xml
@@ -110,6 +110,7 @@
             android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|keyboard|navigation|uiMode"
             android:launchMode="singleTop"
             android:process=":game"
+            android:windowSoftInputMode="adjustResize"
             android:screenOrientation="sensorLandscape" />
 
         <provider

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -564,15 +564,6 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 }
 
                 @Override
-                public void onKeyboardPanningChanged() {
-                    if (LauncherPreferences.PREF_KEYBOARD_PANNING) {
-                        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
-                    } else {
-                        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
-                    }
-                }
-
-                @Override
                 public void onGyroStateChanged() {
                     mGyroControl.updateOrientation();
                     if (PREF_ENABLE_GYRO) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -32,6 +32,7 @@ import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
@@ -110,6 +111,13 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (LauncherPreferences.PREF_KEYBOARD_PANNING) {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+        } else {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
+        }
+
         if (LauncherPreferences.PREF_GAMEPAD_SDL_PASSTHRU) {
             // TODO: Use lower level HID capture that needs a dialogue box from the user for the
             // app to fully take focus of the input devices. Might cause issues with older android
@@ -507,6 +515,15 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                 public void onResolutionChanged() {
                     minecraftGLView.refreshSize();
                     mHotbarView.onResolutionChanged();
+                }
+
+                @Override
+                public void onKeyboardPanningChanged() {
+                    if (LauncherPreferences.PREF_KEYBOARD_PANNING) {
+                        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+                    } else {
+                        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
+                    }
                 }
 
                 @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -109,10 +109,8 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
 
     @Nullable
     private RectF inputAreaRect;
-    @Nullable
-    private WindowInsetsAnimationCompat imeAnimation;
-    private int fullImeHeight;
-    private int targetImeHeight;
+    private int imeHeight;
+    private boolean hasOngoingImeAnimation;
 
     MinecraftProfile minecraftProfile;
 
@@ -204,53 +202,35 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         MCOptionUtils.addMCOptionListener(optionListener);
         mControlLayout.setModifiable(false);
 
-        // Listen to IME offsets
+        // Listen to IME insets animation
         ViewCompat.setWindowInsetsAnimationCallback(contentFrame, new WindowInsetsAnimationCompat.Callback(WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP) {
             @Override
             public void onPrepare(@NonNull WindowInsetsAnimationCompat animation) {
                 if ((animation.getTypeMask() & WindowInsetsCompat.Type.ime()) != 0) {
-                    imeAnimation = animation;
+                    hasOngoingImeAnimation = true;
                 }
-            }
-
-            @NonNull
-            @Override
-            public WindowInsetsAnimationCompat.BoundsCompat onStart(@NonNull WindowInsetsAnimationCompat animation, @NonNull WindowInsetsAnimationCompat.BoundsCompat bounds) {
-                if ((animation.getTypeMask() & WindowInsetsCompat.Type.ime()) != 0) {
-                    refreshImeTranslation();
-                }
-                return bounds;
             }
 
             @NonNull
             @Override
             public WindowInsetsCompat onProgress(@NonNull WindowInsetsCompat insets, @NonNull List<WindowInsetsAnimationCompat> runningAnimations) {
-                // Find an IME animation
-                for (WindowInsetsAnimationCompat animation : runningAnimations) {
-                    if ((animation.getTypeMask() & WindowInsetsCompat.Type.ime()) != 0) {
-                        imeAnimation = animation;
-                        break;
-                    }
-                }
+                imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
                 refreshImeTranslation();
                 return insets;
             }
 
             @Override
             public void onEnd(@NonNull WindowInsetsAnimationCompat animation) {
-                imeAnimation = null;
-                refreshImeTranslation();
+                if ((animation.getTypeMask() & WindowInsetsCompat.Type.ime()) != 0) {
+                    hasOngoingImeAnimation = false;
+                }
             }
         });
         ViewCompat.setOnApplyWindowInsetsListener(contentFrame, (v, insets) -> {
-            boolean imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
-            if (imeVisible) {
-                int height = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
-                fullImeHeight = height;
-                targetImeHeight = height;
-            } else {
-                // Retain last value of fullImeHeight
-                targetImeHeight = 0;
+            // Only refresh translation if IME change insets itself, not the animation
+            if (!hasOngoingImeAnimation) {
+                imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+                refreshImeTranslation();
             }
             return insets;
         });
@@ -792,7 +772,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     }
 
     private void refreshImeTranslation() {
-        if (fullImeHeight == 0) {
+        if (imeHeight == 0) {
             // Early exit
             contentFrame.setTranslationY(0);
             return;
@@ -808,20 +788,8 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
             return;
         }
 
-        int animationImeHeight;
-        if (imeAnimation != null) {
-            if (targetImeHeight == 0) {
-                // Collapsing
-                animationImeHeight = (int) (fullImeHeight * (1 - imeAnimation.getInterpolatedFraction()));
-            } else {
-                // Expanding
-                animationImeHeight = (int) (targetImeHeight * imeAnimation.getInterpolatedFraction());
-            }
-        } else {
-            animationImeHeight = targetImeHeight;
-        }
         int bottomDistance = contentFrame.getHeight() - inputAreaBottom;
-        int bottomPadding = Math.max(animationImeHeight - bottomDistance, 0);
+        int bottomPadding = Math.max(imeHeight - bottomDistance, 0);
 
         contentFrame.setTranslationY(-bottomPadding);
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.RectF;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Build;
@@ -35,13 +36,19 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.FrameLayout;
 import android.widget.ListView;
 import android.widget.Toast;
 
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsAnimationCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 
 import com.kdt.LoggerView;
@@ -76,9 +83,10 @@ import org.lwjgl.glfw.CallbackBridge;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
-public class MainActivity extends BaseActivity implements ControlButtonMenuListener, EditorExitable, ServiceConnection {
+public class MainActivity extends BaseActivity implements ControlButtonMenuListener, EditorExitable, ServiceConnection, TouchControllerInputView.InputAreaRectListener {
     public static volatile ClipboardManager GLOBAL_CLIPBOARD;
     public static final String TAG = "MainActivity";
     public static final String INTENT_MINECRAFT_VERSION = "intent_version";
@@ -97,6 +105,14 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     private GyroControl mGyroControl = null;
     private ControlLayout mControlLayout;
     private HotbarView mHotbarView;
+    private FrameLayout contentFrame;
+
+    @Nullable
+    private RectF inputAreaRect;
+    @Nullable
+    private WindowInsetsAnimationCompat imeAnimation;
+    private int fullImeHeight;
+    private int targetImeHeight;
 
     MinecraftProfile minecraftProfile;
 
@@ -111,12 +127,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        if (LauncherPreferences.PREF_KEYBOARD_PANNING) {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
-        } else {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
-        }
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
 
         if (LauncherPreferences.PREF_GAMEPAD_SDL_PASSTHRU) {
             // TODO: Use lower level HID capture that needs a dialogue box from the user for the
@@ -193,6 +204,57 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         MCOptionUtils.addMCOptionListener(optionListener);
         mControlLayout.setModifiable(false);
 
+        // Listen to IME offsets
+        ViewCompat.setWindowInsetsAnimationCallback(contentFrame, new WindowInsetsAnimationCompat.Callback(WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP) {
+            @Override
+            public void onPrepare(@NonNull WindowInsetsAnimationCompat animation) {
+                if ((animation.getTypeMask() & WindowInsetsCompat.Type.ime()) != 0) {
+                    imeAnimation = animation;
+                }
+            }
+
+            @NonNull
+            @Override
+            public WindowInsetsAnimationCompat.BoundsCompat onStart(@NonNull WindowInsetsAnimationCompat animation, @NonNull WindowInsetsAnimationCompat.BoundsCompat bounds) {
+                if ((animation.getTypeMask() & WindowInsetsCompat.Type.ime()) != 0) {
+                    refreshImeTranslation();
+                }
+                return bounds;
+            }
+
+            @NonNull
+            @Override
+            public WindowInsetsCompat onProgress(@NonNull WindowInsetsCompat insets, @NonNull List<WindowInsetsAnimationCompat> runningAnimations) {
+                // Find an IME animation
+                for (WindowInsetsAnimationCompat animation : runningAnimations) {
+                    if ((animation.getTypeMask() & WindowInsetsCompat.Type.ime()) != 0) {
+                        imeAnimation = animation;
+                        break;
+                    }
+                }
+                refreshImeTranslation();
+                return insets;
+            }
+
+            @Override
+            public void onEnd(@NonNull WindowInsetsAnimationCompat animation) {
+                imeAnimation = null;
+                refreshImeTranslation();
+            }
+        });
+        ViewCompat.setOnApplyWindowInsetsListener(contentFrame, (v, insets) -> {
+            boolean imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
+            if (imeVisible) {
+                int height = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+                fullImeHeight = height;
+                targetImeHeight = height;
+            } else {
+                // Retain last value of fullImeHeight
+                targetImeHeight = 0;
+            }
+            return insets;
+        });
+
         // Set the activity for the executor. Must do this here, or else Tools.showErrorRemote() may not
         // execute the correct method
         ContextExecutor.setActivity(this);
@@ -217,7 +279,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
             GLOBAL_CLIPBOARD = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
             touchCharInput.setCharacterSender(new LwjglCharSender());
 
-            touchControllerInputView.setSize(minecraftGLView.getWidth(), minecraftGLView.getHeight());
+            touchControllerInputView.setInputAreaRectListener(this);
 
             if(minecraftProfile.pojavRendererName != null) {
                 Log.i("RdrDebug","__P_renderer="+minecraftProfile.pojavRendererName);
@@ -267,6 +329,9 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
                     if (PREF_VIRTUAL_MOUSE_START) {
                         touchpad.post(() -> touchpad.switchState());
                     }
+
+                    // At this time, correct size is known
+                    touchControllerInputView.setSize(minecraftGLView.getWidth(), minecraftGLView.getHeight());
 
                     runCraft(finalVersion, mVersionInfo);
                 }catch (Throwable e){
@@ -322,6 +387,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         touchControllerInputView = findViewById(R.id.touch_controller_input);
         mDrawerPullButton = findViewById(R.id.drawer_button);
         mHotbarView = findViewById(R.id.hotbar_view);
+        contentFrame = findViewById(R.id.content_frame);
     }
 
     @Override
@@ -717,5 +783,46 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     @Override
     public void onBackPressed() {
         super.onBackPressed();
+    }
+
+    @Override
+    public void updateInputAreaRect(@Nullable RectF rect) {
+        inputAreaRect = rect;
+        refreshImeTranslation();
+    }
+
+    private void refreshImeTranslation() {
+        if (fullImeHeight == 0) {
+            // Early exit
+            contentFrame.setTranslationY(0);
+            return;
+        }
+
+        int inputAreaBottom;
+        if (inputAreaRect != null) {
+            inputAreaBottom = (int) inputAreaRect.bottom;
+        } else if (LauncherPreferences.PREF_KEYBOARD_PANNING) {
+            inputAreaBottom = contentFrame.getHeight();
+        } else {
+            contentFrame.setTranslationY(0);
+            return;
+        }
+
+        int animationImeHeight;
+        if (imeAnimation != null) {
+            if (targetImeHeight == 0) {
+                // Collapsing
+                animationImeHeight = (int) (fullImeHeight * (1 - imeAnimation.getInterpolatedFraction()));
+            } else {
+                // Expanding
+                animationImeHeight = (int) (targetImeHeight * imeAnimation.getInterpolatedFraction());
+            }
+        } else {
+            animationImeHeight = targetImeHeight;
+        }
+        int bottomDistance = contentFrame.getHeight() - inputAreaBottom;
+        int bottomPadding = Math.max(animationImeHeight - bottomDistance, 0);
+
+        contentFrame.setTranslationY(-bottomPadding);
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/Touchpad.java
@@ -123,9 +123,11 @@ public class Touchpad extends View implements GrabListener, AbstractTouchpad {
 
     @Override
     public void applyMotionVector(float x, float y) {
-        mMouseX = Math.max(0, Math.min(currentDisplayMetrics.widthPixels, mMouseX + x * LauncherPreferences.PREF_MOUSESPEED));
-        mMouseY = Math.max(0, Math.min(currentDisplayMetrics.heightPixels, mMouseY + y * LauncherPreferences.PREF_MOUSESPEED));
-        updateMousePosition();
+        if (mDisplayState) { // Make sure no motion leaks through when disabling a moving cursor
+            mMouseX = Math.max(0, Math.min(currentDisplayMetrics.widthPixels, mMouseX + x * LauncherPreferences.PREF_MOUSESPEED));
+            mMouseY = Math.max(0, Math.min(currentDisplayMetrics.heightPixels, mMouseY + y * LauncherPreferences.PREF_MOUSESPEED));
+            updateMousePosition();
+        }
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -75,6 +75,7 @@ public class LauncherPreferences {
     public static int PREF_TOUCHCONTROLLER_VIBRATE_LENGTH = 100;
 
     public static boolean PREF_MOUSE_GRAB_FORCE = false;
+    public static boolean PREF_KEYBOARD_PANNING = true;
 
 
     public static void loadPreferences(Context ctx) {
@@ -121,6 +122,7 @@ public class LauncherPreferences {
         PREF_FORCE_ENABLE_TOUCHCONTROLLER = DEFAULT_PREF.getBoolean("forceEnableTouchController", false);
         PREF_TOUCHCONTROLLER_VIBRATE_LENGTH = DEFAULT_PREF.getInt("touchControllerVibrateLength", 100);
         PREF_MOUSE_GRAB_FORCE = DEFAULT_PREF.getBoolean("always_grab_mouse", false);
+        PREF_KEYBOARD_PANNING = DEFAULT_PREF.getBoolean("keyboardPanning", true);
 
         String argLwjglLibname = "-Dorg.lwjgl.opengl.libname=";
         for (String arg : JREUtils.parseJavaArguments(PREF_CUSTOM_JAVA_ARGS)) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
@@ -137,7 +137,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
 
         mKeyboardPanningSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
             PREF_KEYBOARD_PANNING = isChecked;
-            onKeyboardPanningChanged();
             mEditor.putBoolean("keyboardPanning", isChecked);
         });
 
@@ -261,7 +260,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
 
             onGyroStateChanged();
             onResolutionChanged();
-            onKeyboardPanningChanged();
         }
 
         disappear(true);
@@ -269,9 +267,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
 
     /** Called when the resolution is changed. Use {@link LauncherPreferences#PREF_SCALE_FACTOR} */
     public abstract void onResolutionChanged();
-
-    /** Called when the keyboard panning state is changed. Use {@link LauncherPreferences#PREF_KEYBOARD_PANNING} */
-    public abstract void onKeyboardPanningChanged();
 
     /** Called when the gyro state is changed.
      * Use {@link LauncherPreferences#PREF_ENABLE_GYRO}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
@@ -5,6 +5,7 @@ import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_ENABLE_GYRO;
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_GYRO_INVERT_X;
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_GYRO_INVERT_Y;
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_GYRO_SENSITIVITY;
+import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_KEYBOARD_PANNING;
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_LONGPRESS_TRIGGER;
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_MOUSESPEED;
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_MOUSE_GRAB_FORCE;
@@ -32,11 +33,11 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
 
     private SharedPreferences.Editor mEditor;
     @SuppressLint("UseSwitchCompatOrMaterialCode")
-    private Switch mGyroSwitch, mGyroXSwitch, mGyroYSwitch, mGestureSwitch, mMouseGrabSwitch;
+    private Switch mGyroSwitch, mGyroXSwitch, mGyroYSwitch, mGestureSwitch, mMouseGrabSwitch, mKeyboardPanningSwitch;
     private CustomSeekbar mGyroSensitivityBar, mMouseSpeedBar, mGestureDelayBar, mResolutionBar;
     private TextView mGyroSensitivityText, mGyroSensitivityDisplayText, mMouseSpeedText, mGestureDelayText, mGestureDelayDisplayText, mResolutionText;
 
-    private boolean mOriginalGyroEnabled, mOriginalGyroXEnabled, mOriginalGyroYEnabled, mOriginalGestureDisabled, mOriginalMouseGrab;
+    private boolean mOriginalGyroEnabled, mOriginalGyroXEnabled, mOriginalGyroYEnabled, mOriginalGestureDisabled, mOriginalMouseGrab, mOriginalKeyboardPanning;
     private float mOriginalGyroSensitivity, mOriginalMouseSpeed, mOriginalResolution;
     private int mOriginalGestureDelay;
 
@@ -67,6 +68,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mGyroYSwitch = mDialogContent.findViewById(R.id.checkboxGyroY);
         mGestureSwitch = mDialogContent.findViewById(R.id.checkboxGesture);
         mMouseGrabSwitch = mDialogContent.findViewById(R.id.always_grab_mouse_side_dialog);
+        mKeyboardPanningSwitch = mDialogContent.findViewById(R.id.checkboxKeyboardPanning);
 
         mGyroSensitivityBar = mDialogContent.findViewById(R.id.editGyro_seekbar);
         mMouseSpeedBar = mDialogContent.findViewById(R.id.editMouseSpeed_seekbar);
@@ -89,6 +91,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mOriginalGyroYEnabled = PREF_GYRO_INVERT_Y;
         mOriginalGestureDisabled = PREF_DISABLE_GESTURES;
         mOriginalMouseGrab = PREF_MOUSE_GRAB_FORCE;
+        mOriginalKeyboardPanning = PREF_KEYBOARD_PANNING;
 
         mOriginalGyroSensitivity = PREF_GYRO_SENSITIVITY;
         mOriginalMouseSpeed = PREF_MOUSESPEED;
@@ -100,6 +103,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mGyroYSwitch.setChecked(mOriginalGyroYEnabled);
         mGestureSwitch.setChecked(mOriginalGestureDisabled);
         mMouseGrabSwitch.setChecked(mOriginalMouseGrab);
+        mKeyboardPanningSwitch.setChecked(mOriginalKeyboardPanning);
 
         mGyroSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
             PREF_ENABLE_GYRO = isChecked;
@@ -129,6 +133,12 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mMouseGrabSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
             PREF_MOUSE_GRAB_FORCE = isChecked;
             mEditor.putBoolean("always_grab_mouse", isChecked);
+        });
+
+        mKeyboardPanningSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            PREF_KEYBOARD_PANNING = isChecked;
+            onKeyboardPanningChanged();
+            mEditor.putBoolean("keyboardPanning", isChecked);
         });
 
         mGyroSensitivityBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
@@ -217,6 +227,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mGyroYSwitch.setOnCheckedChangeListener(null);
         mGestureSwitch.setOnCheckedChangeListener(null);
         mMouseGrabSwitch.setOnCheckedChangeListener(null);
+        mKeyboardPanningSwitch.setOnCheckedChangeListener(null);
 
         mGyroSensitivityBar.setOnSeekBarChangeListener(null);
         mMouseSpeedBar.setOnSeekBarChangeListener(null);
@@ -241,6 +252,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
             PREF_GYRO_INVERT_Y = mOriginalGyroYEnabled;
             PREF_DISABLE_GESTURES = mOriginalGestureDisabled;
             PREF_MOUSE_GRAB_FORCE = mOriginalMouseGrab;
+            PREF_KEYBOARD_PANNING = mOriginalKeyboardPanning;
 
             PREF_GYRO_SENSITIVITY = mOriginalGyroSensitivity;
             PREF_MOUSESPEED = mOriginalMouseSpeed;
@@ -249,6 +261,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
 
             onGyroStateChanged();
             onResolutionChanged();
+            onKeyboardPanningChanged();
         }
 
         disappear(true);
@@ -256,6 +269,9 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
 
     /** Called when the resolution is changed. Use {@link LauncherPreferences#PREF_SCALE_FACTOR} */
     public abstract void onResolutionChanged();
+
+    /** Called when the keyboard panning state is changed. Use {@link LauncherPreferences#PREF_KEYBOARD_PANNING} */
+    public abstract void onKeyboardPanningChanged();
 
     /** Called when the gyro state is changed.
      * Use {@link LauncherPreferences#PREF_ENABLE_GYRO}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerInputView.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerInputView.java
@@ -113,14 +113,18 @@ public class TouchControllerInputView extends View implements LauncherProxyClien
 
     @Override
     public void updateCursor(FloatRect cursorRect) {
-        TouchControllerInputView.this.cursorRect = cursorRect;
-        updateCursorAnchorInfo();
+        post(() -> {
+            TouchControllerInputView.this.cursorRect = cursorRect;
+            updateCursorAnchorInfo();
+        });
     }
 
     @Override
     public void updateArea(FloatRect inputAreaRect) {
-        TouchControllerInputView.this.inputAreaRect = inputAreaRect;
-        updateCursorAnchorInfo();
+        post(() -> {
+            TouchControllerInputView.this.inputAreaRect = inputAreaRect;
+            updateCursorAnchorInfo();
+        });
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerInputView.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerInputView.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.graphics.RectF;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -39,8 +40,8 @@ import static top.fifthlight.touchcontroller.proxy.message.input.TextInputStateK
 import net.kdt.pojavlaunch.EfficientAndroidLWJGLKeycode;
 import net.kdt.pojavlaunch.customcontrols.keyboard.CharacterSenderStrategy;
 
-public class TouchControllerInputView extends View {
-    public boolean disableFullScreenInput = false;
+public class TouchControllerInputView extends View implements LauncherProxyClient.InputHandler, LauncherProxyClient.KeyboardShowHandler {
+    public boolean disableFullScreenInput = true;
     private LauncherProxyClient client;
     private int width = -1;
     private int height = -1;
@@ -52,7 +53,11 @@ public class TouchControllerInputView extends View {
     private FloatRect cursorRect;
     private FloatRect inputAreaRect;
     private InputConnectionImpl inputConnection;
-    private final LauncherProxyClient.InputHandler inputHandler;
+
+    public interface InputAreaRectListener {
+        void updateInputAreaRect(@Nullable RectF rect);
+    }
+    private InputAreaRectListener inputAreaRectListener;
 
     public TouchControllerInputView(Context context) {
         this(context, null);
@@ -68,56 +73,67 @@ public class TouchControllerInputView extends View {
         if (inputMethodManager == null) {
             throw new IllegalStateException("No InputMethodManager service");
         }
-
-        inputHandler = new LauncherProxyClient.InputHandler() {
-            @Override
-            public void updateState(TextInputState textInputState) {
-                post(() -> {
-                    TextInputState prevState = inputState;
-                    inputState = textInputState;
-                    if (textInputState != null) {
-                        setVisibility(VISIBLE);
-                        setFocusable(true);
-                    }
-                    if (prevState == null && textInputState != null) {
-                        setFocusableInTouchMode(true);
-                        clearFocus();
-                        requestFocus();
-                        inputMethodManager.showSoftInput(
-                                TouchControllerInputView.this,
-                                InputMethodManager.SHOW_IMPLICIT
-                        );
-                    } else if (prevState != null && textInputState == null) {
-                        clearFocus();
-                        inputMethodManager.hideSoftInputFromWindow(
-                                getWindowToken(),
-                                InputMethodManager.HIDE_IMPLICIT_ONLY
-                        );
-                    }
-                    if (textInputState != null) {
-                        if (inputConnection != null) {
-                            inputConnection.updateState(textInputState);
-                        }
-                    } else {
-                        setVisibility(GONE);
-                        setFocusable(false);
-                    }
-                });
-            }
-
-            @Override
-            public void updateCursor(FloatRect cursorRect) {
-                TouchControllerInputView.this.cursorRect = cursorRect;
-                updateCursorAnchorInfo();
-            }
-
-            @Override
-            public void updateArea(FloatRect inputAreaRect) {
-                TouchControllerInputView.this.inputAreaRect = inputAreaRect;
-                updateCursorAnchorInfo();
-            }
-        };
     }
+
+
+    @Override
+    public void updateState(TextInputState textInputState) {
+        post(() -> {
+            TextInputState prevState = inputState;
+            inputState = textInputState;
+            if (textInputState != null) {
+                setVisibility(VISIBLE);
+                setFocusable(true);
+            }
+            if (prevState == null && textInputState != null) {
+                setFocusableInTouchMode(true);
+                clearFocus();
+                requestFocus();
+                inputMethodManager.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
+            } else if (prevState != null && textInputState == null) {
+                clearFocus();
+                inputMethodManager.hideSoftInputFromWindow(
+                        getWindowToken(),
+                        InputMethodManager.HIDE_IMPLICIT_ONLY
+                );
+            }
+            if (textInputState != null) {
+                if (inputConnection != null) {
+                    inputConnection.updateState(textInputState);
+                }
+            } else {
+                setVisibility(GONE);
+                setFocusable(false);
+                if (inputAreaRectListener != null) {
+                    inputAreaRectListener.updateInputAreaRect(null);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void updateCursor(FloatRect cursorRect) {
+        TouchControllerInputView.this.cursorRect = cursorRect;
+        updateCursorAnchorInfo();
+    }
+
+    @Override
+    public void updateArea(FloatRect inputAreaRect) {
+        TouchControllerInputView.this.inputAreaRect = inputAreaRect;
+        updateCursorAnchorInfo();
+    }
+
+    @Override
+    public void showKeyboard() {
+        post(() -> {
+            if (inputState != null) {
+                inputMethodManager.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
+            }
+        });
+    }
+
+    @Override
+    public void hideKeyboard() {}
 
     private static boolean isEmpty(TextRange range) {
         return range.getLength() == 0;
@@ -143,16 +159,22 @@ public class TouchControllerInputView extends View {
         LauncherProxyClient prev = this.client;
         if (prev != null) {
             prev.setInputHandler(null);
+            prev.setKeyboardShowHandler(null);
         }
         this.client = value;
         if (value != null) {
-            value.setInputHandler(inputHandler);
+            value.setInputHandler(this);
+            value.setKeyboardShowHandler(this);
         }
     }
 
     public void setSize(int width, int height) {
         this.width = width;
         this.height = height;
+    }
+
+    public void setInputAreaRectListener(InputAreaRectListener listener) {
+        inputAreaRectListener = listener;
     }
 
     @Override
@@ -198,16 +220,18 @@ public class TouchControllerInputView extends View {
             );
         }
         if (inputAreaRect != null) {
+            RectF rect = new RectF(
+                    inputAreaRect.getLeft() * width,
+                    inputAreaRect.getTop() * height,
+                    (inputAreaRect.getLeft() + inputAreaRect.getWidth()) * width,
+                    (inputAreaRect.getTop() + inputAreaRect.getHeight()) * height
+            );
+            if (inputAreaRectListener != null) {
+                inputAreaRectListener.updateInputAreaRect(rect);
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 EditorBoundsInfo editorBoundsInfo = new EditorBoundsInfo.Builder()
-                        .setEditorBounds(
-                                new RectF(
-                                        inputAreaRect.getLeft() * width,
-                                        inputAreaRect.getTop() * height,
-                                        (inputAreaRect.getLeft() + inputAreaRect.getWidth()) * width,
-                                        (inputAreaRect.getTop() + inputAreaRect.getHeight()) * height
-                                )
-                        )
+                        .setEditorBounds(rect)
                         .build();
                 builder.setEditorBoundsInfo(editorBoundsInfo);
             }
@@ -307,6 +331,9 @@ public class TouchControllerInputView extends View {
 
         @Override
         public void closeConnection() {
+            if (inputAreaRectListener != null) {
+                inputAreaRectListener.updateInputAreaRect(null);
+            }
         }
 
         @Override
@@ -489,7 +516,7 @@ public class TouchControllerInputView extends View {
 
         @Nullable
         @Override
-        public android.os.Handler getHandler() {
+        public Handler getHandler() {
             return null;
         }
 
@@ -562,12 +589,12 @@ public class TouchControllerInputView extends View {
 
         @Override
         public boolean performEditorAction(int editorAction) {
-            return false;
+            return true;
         }
 
         @Override
         public boolean performPrivateCommand(String action, Bundle data) {
-            return false;
+            return true;
         }
 
         @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerUtils.java
@@ -106,7 +106,7 @@ public class TouchControllerUtils {
             Log.w("TouchController", "Failed to set TouchController environment variable", e);
         }
         MessageTransport transport = UnixSocketTransportKt.UnixSocketTransport(socketName);
-        proxyClient = new LauncherProxyClient(transport, Set.of(PlatformCapability.TEXT_STATUS));
+        proxyClient = new LauncherProxyClient(transport, Set.of(PlatformCapability.TEXT_STATUS, PlatformCapability.KEYBOARD_SHOW));
         proxyClient.run();
         touchControllerInputView.setClient(proxyClient);
         Vibrator vibrator = ContextCompat.getSystemService(context, Vibrator.class);

--- a/app_pojavlauncher/src/main/res/layout/activity_basemain.xml
+++ b/app_pojavlauncher/src/main/res/layout/activity_basemain.xml
@@ -38,11 +38,24 @@
 				android:translationZ="1dp"
 				android:visibility="gone"/>
 
+		<!-- This is a horrible hack that forces android to properly redraw ControlLayout
+			 when keyboard causes MainActivity to pan offscreen, which can cause the top part
+			 of ControLayout to just be grpahically cut out. This stops that, somehow...      -->
+			<View
+				android:layout_height="match_parent"
+				android:layout_width="match_parent"
+				android:orientation="vertical"
+				android:focusable="false"
+				android:translationZ="1dp"
+				android:visibility="visible"
+				android:importantForAccessibility="no"
+				android:background="@android:color/transparent"/>
 
 			<net.kdt.pojavlaunch.customcontrols.keyboard.TouchCharInput
 				android:id="@+id/mainTouchCharInput"
 				android:layout_width="1dp"
 				android:layout_height="1dp"
+				android:layout_gravity="bottom"
 				android:background="@android:color/darker_gray"
 				android:ems="10"
 				android:imeOptions="flagNoFullscreen|flagNoExtractUi|flagNoPersonalizedLearning|actionDone"
@@ -52,7 +65,8 @@
 			<net.kdt.pojavlaunch.utils.TouchControllerInputView
 				android:id="@+id/touch_controller_input"
 				android:layout_width="1dp"
-				android:layout_height="1dp" />
+				android:layout_height="1dp"
+				android:layout_gravity="bottom" />
 
 			<net.kdt.pojavlaunch.customcontrols.handleview.DrawerPullButton
 				android:id="@+id/drawer_button"

--- a/app_pojavlauncher/src/main/res/layout/dialog_quick_setting.xml
+++ b/app_pojavlauncher/src/main/res/layout/dialog_quick_setting.xml
@@ -209,8 +209,17 @@
         android:text="@string/mcl_setting_title_grab_mouse"
 
 
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/editGestureDelay_seekbar"
+        tools:ignore="UseSwitchCompatOrMaterialXml" />
+
+    <Switch
+        android:id="@+id/checkboxKeyboardPanning"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/_36sdp"
+        android:text="@string/mcl_setting_title_keyboard_panning"
+
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/always_grab_mouse_side_dialog"
         tools:ignore="UseSwitchCompatOrMaterialXml" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -176,6 +176,8 @@
     <string name="mcl_setting_subtitle_mousespeed">Changes the speed of the virtual mouse.</string>
     <string name="mcl_setting_title_grab_mouse">Use virtual cursor</string>
     <string name="mcl_setting_subtitle_grab_mouse">Ensures the cursor stays inside the game. Prevents mouse from clicking touch control layout.</string>
+    <string name="mcl_setting_title_keyboard_panning">Keyboard panning</string>
+    <string name="mcl_setting_subtitle_keyboard_panning">Shift the screen upwards when the keyboard is open.</string>
     <string name="customctrl_passthru">Mouse pass-thru</string>
     <string name="customctrl_swipeable">Swipeable</string>
     <string name="customctrl_forward_lock">Forward lock</string>

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -62,6 +62,11 @@
             android:title="@string/mcl_setting_title_buttonallcaps"
             android:summary="@string/mcl_setting_subtitle_buttonallcaps"
             />
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="keyboardPanning"
+            android:summary="@string/mcl_setting_subtitle_keyboard_panning"
+            android:title="@string/mcl_setting_title_keyboard_panning" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Add support for [IME animation](https://developer.android.com/develop/ui/views/layout/sw-keyboard) for input boxes in TouchController.

Also add KEYBOARD_SHOW capability in proxy client, so it is possible to click the input box to show the soft keyboard when users close soft keyboard manually.

Fixed return value performEditorAction and performPrivateCommand, they should be true unless InputConnection is not valid.

Fixed the timing of initial touchControllerInputView.setSize call, because it is called with zero before.

Set disableFullScreenInput to true, as most users don't want full screen(extracted) input.

I modified MainActivity a lot and may break things, so please review and test it extensively.