### PR TITLE
remove check against Java 17+ for the "Execute a .jar" option in the launcher

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
@@ -212,11 +212,6 @@ public class JavaGUILauncherActivity extends BaseActivity implements View.OnTouc
         }
         Runtime selectedRuntime = MultiRTUtils.forceReread(nearestRuntime);
         int selectedJavaVersion = Math.max(javaVersion, selectedRuntime.javaVersion);
-        // Don't allow versions higher than Java 17 because our caciocavallo implementation does not allow for it
-        if(selectedJavaVersion > 17) {
-            finalErrorDialog(getString(R.string.execute_jar_incompatible_runtime, selectedJavaVersion));
-            return null;
-        }
         return selectedRuntime;
     }
 

--- a/app_pojavlauncher/src/main/res/values-ar/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ar/strings.xml
@@ -318,7 +318,6 @@
     <string name="log_view_button_output_on">المخرجات\nمفعلة</string>
     <string name="log_view_label_log_output">سِجل الإخراج:</string>
     <string name="execute_jar_failed_to_read_file">فشل في قراءة ملف .jar</string>
-    <string name="execute_jar_incompatible_runtime">تنفيذ وظيفة .jar غير متوافق مع Java %d</string>
     <string name="controller_button_select">اختر</string>
     <string name="controller_button_trigger_left">الزناد الأيسر</string>
     <string name="controller_button_trigger_right">الزناد الأيمن</string>

--- a/app_pojavlauncher/src/main/res/values-cs/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-cs/strings.xml
@@ -348,7 +348,6 @@
     <string name="log_view_button_output_on">Výstup\nZapnuto</string>
     <string name="log_view_label_log_output">Výstup záznamu:</string>
     <string name="execute_jar_failed_to_read_file">Selhalo čtení souboru .jar</string>
-    <string name="execute_jar_incompatible_runtime">Funkce spouštění .jar souboru není kompatibilní s Javou %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-de/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-de/strings.xml
@@ -347,7 +347,6 @@ Um die offizielle Download-Quelle zu verwenden, drücke \"Auf offizielle Seite u
     <string name="log_view_button_output_on">Ausgabe\nAN</string>
     <string name="log_view_label_log_output">Protokoll-Ausgabe:</string>
     <string name="execute_jar_failed_to_read_file">Fehler beim Lesen der .jar-Datei</string>
-    <string name="execute_jar_incompatible_runtime">Die Ausführung der .jar-Funktion ist nicht kompatibel mit Java %d</string>
     <string name="controller_button_select">Auswählen</string>
     <string name="controller_button_trigger_left">Linker Trigger</string>
     <string name="controller_button_trigger_right">Rechter Trigger</string>

--- a/app_pojavlauncher/src/main/res/values-es/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-es/strings.xml
@@ -332,7 +332,6 @@
     <string name="log_view_button_output_on">Salida\nEncendido</string>
     <string name="log_view_label_log_output">Salida del registro:</string>
     <string name="execute_jar_failed_to_read_file">Falló al leer el archivo .jar</string>
-    <string name="execute_jar_incompatible_runtime">La característica para ejecutar .jar no es compatible con Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-fr/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-fr/strings.xml
@@ -341,7 +341,6 @@
     <string name="log_view_button_output_on">Sortie\nDésactivée</string>
     <string name="log_view_label_log_output">Sortie des logs :</string>
     <string name="execute_jar_failed_to_read_file">Impossible de lire le fichier .jar</string>
-    <string name="execute_jar_incompatible_runtime">La fonction \"Exécuter le fichier .jar\" n\'est pas compatible avec Java%d</string>
     <string name="controller_button_select">Sélectionner</string>
     <string name="controller_button_trigger_left">Gâchette gauche</string>
     <string name="controller_button_trigger_right">Gâchette droite</string>

--- a/app_pojavlauncher/src/main/res/values-hu/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-hu/strings.xml
@@ -350,7 +350,6 @@ mcl_indítás_letöltés_folyamatban"</string>
     <string name="log_view_button_output_on">Kimenet\nBE</string>
     <string name="log_view_label_log_output">Napló kimenet:</string>
     <string name="execute_jar_failed_to_read_file">A .jar beolvasása sikertelen</string>
-    <string name="execute_jar_incompatible_runtime">A \".jar futtatása\" nem kompatibilis a Java %d-val/vel</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-in/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-in/strings.xml
@@ -348,7 +348,6 @@
     <string name="log_view_button_output_on">Keluaran\nHIDUP</string>
     <string name="log_view_label_log_output">Keluaran log:</string>
     <string name="execute_jar_failed_to_read_file">Gagal membaca dokumen .jar</string>
-    <string name="execute_jar_incompatible_runtime">Fitur eksekusi .jar tidak kompatibel dengan Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-it/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-it/strings.xml
@@ -345,7 +345,6 @@ se vuoi scaricare dalla sorgente ufficiale premi \"Passa al sito ufficiale"\ e r
     <string name="log_view_button_output_on">Output\nON</string>
     <string name="log_view_label_log_output">Registro log:</string>
     <string name="execute_jar_failed_to_read_file">Impossibile leggere il file .jar</string>
-    <string name="execute_jar_incompatible_runtime">La funzione Esegui .jar non è compatibile con Java %d</string>
     <string name="controller_button_select">Seleziona</string>
     <string name="controller_button_trigger_left">Grilletto sinistro</string>
     <string name="controller_button_trigger_right">Grilletto destro</string>

--- a/app_pojavlauncher/src/main/res/values-iw/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-iw/strings.xml
@@ -336,7 +336,6 @@
     <string name="log_view_button_output_on">פלט\nפעיל</string>
     <string name="log_view_label_log_output">לוג פלט:</string>
     <string name="execute_jar_failed_to_read_file">נכשלה קריאת קובץ ה-.jar</string>
-    <string name="execute_jar_incompatible_runtime">הפעלת .jar אינה תואמת ל-Java %d</string>
     <string name="controller_button_trigger_left">טריגר ימני</string>
     <string name="controller_button_trigger_right">טריגר שמאלי</string>
     <string name="controller_button_shoulder_left">Shoulder ימני</string>

--- a/app_pojavlauncher/src/main/res/values-ko/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ko/strings.xml
@@ -345,7 +345,6 @@
     <string name="log_view_button_output_on">출력\n켬</string>
     <string name="log_view_label_log_output">로그 출력:</string>
     <string name="execute_jar_failed_to_read_file">.jar 파일을 읽지 못했습니다</string>
-    <string name="execute_jar_incompatible_runtime">Java %d는 .jar 실행 기능과 호환되지 않습니다</string>
     <string name="controller_button_select">선택</string>
     <string name="controller_button_trigger_left">좌측 트리거</string>
     <string name="controller_button_trigger_right">우측 트리거</string>

--- a/app_pojavlauncher/src/main/res/values-ms/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ms/strings.xml
@@ -348,7 +348,6 @@
     <string name="log_view_button_output_on">Output\nBUKA</string>
     <string name="log_view_label_log_output">Output log:</string>
     <string name="execute_jar_failed_to_read_file">Gagal membaca fail .jar</string>
-    <string name="execute_jar_incompatible_runtime">Ciri pelaksanaan .jar adalah tidak serasi dengan Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-pl/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-pl/strings.xml
@@ -350,7 +350,6 @@
     <string name="log_view_button_output_on">Wyjście\nWŁ.</string>
     <string name="log_view_label_log_output">Dane wyjściowe dziennika:</string>
     <string name="execute_jar_failed_to_read_file">Nie udało się odczytać pliku .jar</string>
-    <string name="execute_jar_incompatible_runtime">Funkcja uruchamiania plików .jar nie jest zgodna z Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-pt-rBR/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-pt-rBR/strings.xml
@@ -321,7 +321,6 @@
     <string name="log_view_button_output_on">SAÍDA\nLIGADA</string>
     <string name="log_view_label_log_output">Registro de saída:</string>
     <string name="execute_jar_failed_to_read_file">Falha na leitura do arquivo .jar</string>
-    <string name="execute_jar_incompatible_runtime">O recurso Executar .jar não é compatível com Java %d</string>
     <string name="controller_button_select">Selecionar</string>
     <string name="controller_button_trigger_left">Botão esquerdo</string>
     <string name="controller_button_trigger_right">Botão direito</string>

--- a/app_pojavlauncher/src/main/res/values-ru/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-ru/strings.xml
@@ -345,7 +345,6 @@
     <string name="log_view_button_output_on">Вывод\nВКЛ</string>
     <string name="log_view_label_log_output">Журнал:</string>
     <string name="execute_jar_failed_to_read_file">Ошибка чтения .jar файла</string>
-    <string name="execute_jar_incompatible_runtime">Функция запуска .jar файлов несовместима с Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-tr/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-tr/strings.xml
@@ -348,7 +348,6 @@
     <string name="log_view_button_output_on">ÇIKTI\nAÇIK</string>
     <string name="log_view_label_log_output">Konsol çıktısı:</string>
     <string name="execute_jar_failed_to_read_file">.jar dosyası okunurken bir hata oluştu</string>
-    <string name="execute_jar_incompatible_runtime">.jar çalıştırma özelliği Java %d ile uyumlu değil</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-uk/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-uk/strings.xml
@@ -350,7 +350,6 @@
     <string name="log_view_button_output_on">Вивід\nУВІМК.</string>
     <string name="log_view_label_log_output">Вивід журналу:</string>
     <string name="execute_jar_failed_to_read_file">Помилка зчитування файлу .jar</string>
-    <string name="execute_jar_incompatible_runtime">Функція виконання .jar не сумісна з Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-vi/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-vi/strings.xml
@@ -348,7 +348,6 @@
     <string name="log_view_button_output_on">In ra MH\nBật</string>
     <string name="log_view_label_log_output">Đầu ra nhật ký:</string>
     <string name="execute_jar_failed_to_read_file">Không thể đọc tệp .jar</string>
-    <string name="execute_jar_incompatible_runtime">Tính năng chạy tệp .jar không tương thích với Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-zh-rCN/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-zh-rCN/strings.xml
@@ -352,7 +352,6 @@
     <string name="log_view_button_output_on">输出\n开</string>
     <string name="log_view_label_log_output">日志输出：</string>
     <string name="execute_jar_failed_to_read_file">.jar 文件读取失败</string>
-    <string name="execute_jar_incompatible_runtime">执行 .jar 功能与 Java %d 不兼容</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values-zh-rTW/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-zh-rTW/strings.xml
@@ -349,7 +349,6 @@
     <string name="log_view_button_output_on">輸出\n開</string>
     <string name="log_view_label_log_output">記錄檔輸出：</string>
     <string name="execute_jar_failed_to_read_file">.jar 檔案讀取失敗</string>
-    <string name="execute_jar_incompatible_runtime">執行 .jar 功能與 Java %d 不相容</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -396,7 +396,6 @@
     <string name="log_view_button_output_on">Output\nON</string>
     <string name="log_view_label_log_output">Log output:</string>
     <string name="execute_jar_failed_to_read_file">Failed to read the .jar file</string>
-    <string name="execute_jar_incompatible_runtime">Execute .jar feature is not compatible with Java %d</string>
     <string name="controller_button_a">A</string>
     <string name="controller_button_b">B</string>
     <string name="controller_button_x">X</string>


### PR DESCRIPTION
according to the comment above the check, "[the launcher's] caciocavallo implementation does not allow for [using Java 17+ for the "Execute a .jar" feature]". however i removed the check and did some testing and it appears that Java 17+ does in fact work

Ghidra 11.4.3 running with Java 25:
<img width="2712" height="1220" alt="Screenshot_2026-06-22-19-59-52-909_org angelauramc amethyst debug" src="https://github.com/user-attachments/assets/22940ebb-7bab-4791-bf2d-e7a7d1d07a79" />

OptiFine preview installer for Minecraft 26.1.2 with Java 21:
<img width="2712" height="1220" alt="Screenshot_2026-06-22-20-06-54-510_org angelauramc amethyst debug" src="https://github.com/user-attachments/assets/2af71b5b-0a3a-429f-8857-58b820012d68" />

OptiFine installer for Minecraft 1.17.1 with Java 17:
<img width="2712" height="1220" alt="Screenshot_2026-06-22-20-10-44-886_org angelauramc amethyst debug" src="https://github.com/user-attachments/assets/dd803c86-c105-4e68-9ee7-0f31af199515" />
