### PR TITLE
Append either debug or release to the version string

### DIFF
--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -48,7 +48,12 @@ def getVersionName = {
 
     }
 
-    return TAG_STRING.trim().replace("-g", "-") + "-" + semVer
+    def isRelease = project.gradle.startParameter.taskNames.any { it.toLowerCase().contains('release') }
+    if(!isRelease){
+        return TAG_STRING.trim().replace("-g", "-") + "-" + semVer + "-debug"
+    }else {
+        return TAG_STRING.trim().replace("-g", "-") + "-" + semVer + "-release"
+    }
 }
 
 def getCFApiKey = {


### PR DESCRIPTION
Won't be very useful right now, since a lot of users are on an older version (and updating would solve the issue of 26.2 not working most users have anyways), but if a situation like this happens where a certain newer version doesn't work in the future, it would be easier to point users in the Discord to their correct download link just by taking a quick look at the log so they don't have to install the debug build and set up Amethyst all over again.

Appears in the log as
```
--------- Starting game with Launcher Debug!
Info: Launcher version: amethyst-legacy-20260709-88286a5-1.1.5-debug
Info: Architecture: arm64
...
```
(or -release if its a release build)