### PR TITLE
fix: handle NumberFormatException in renderer settings

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceRendererSettingsFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceRendererSettingsFragment.java
@@ -48,17 +48,11 @@ public class LauncherPreferenceRendererSettingsFragment extends LauncherPreferen
                     if (editText.getText().toString().isEmpty()) {
                         editText.setText("0");
                     }
-                    long L;
                     try {
-                        L = Long.parseLong(editText.getText().toString());
-                    } catch(NumberFormatException e) {
-                        L = 0;
-                    }
-                    if (L > Integer.MAX_VALUE) {
-                        editText.setError("Too big! Setting to maximum value");
-                        editText.setText(String.valueOf(Integer.MAX_VALUE));
-                    }
-
+                        if (Long.parseLong(editText.getText().toString()) <= Integer.MAX_VALUE) return;
+                    } catch (NumberFormatException ignored) {}
+                    editText.setError(requireContext().getText(R.string.error_invalid_value));
+                    editText.setText(String.valueOf(Integer.MAX_VALUE));
                 }
             });
         });

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceRendererSettingsFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceRendererSettingsFragment.java
@@ -48,7 +48,13 @@ public class LauncherPreferenceRendererSettingsFragment extends LauncherPreferen
                     if (editText.getText().toString().isEmpty()) {
                         editText.setText("0");
                     }
-                    if (Long.parseLong(editText.getText().toString()) > Integer.MAX_VALUE) {
+                    long L;
+                    try {
+                        L = Long.parseLong(editText.getText().toString());
+                    } catch(NumberFormatException e) {
+                        L = 0;
+                    }
+                    if (L > Integer.MAX_VALUE) {
                         editText.setError("Too big! Setting to maximum value");
                         editText.setText(String.valueOf(Integer.MAX_VALUE));
                     }


### PR DESCRIPTION
Fixes a long parse crash caused by typing lots of zeros in the GLSL cache size field