### PR TITLE
sdl bugfixes

### DIFF
--- a/app_pojavlauncher/src/main/jni/native_hooks/sdl_hook.c
+++ b/app_pojavlauncher/src/main/jni/native_hooks/sdl_hook.c
@@ -58,6 +58,7 @@ static bool custom_SDL_InitSubSystem_Func(SDL_InitFlags flags) {
 
 
 void create_sdl_hooks(bytehook_hook_all_t bytehook_hook_all_p) {
-    bytehook_stub_t stub_SDL_InitSubSystem = bytehook_hook_all_p("libSDL3.so", "SDL_InitSubSystem", &custom_SDL_InitSubSystem_Func, NULL, NULL);
+    // Don't set callee_path_name to anything besides NULL or else it won't be able to find the symbol
+    bytehook_stub_t stub_SDL_InitSubSystem = bytehook_hook_all_p(NULL, "SDL_InitSubSystem", &custom_SDL_InitSubSystem_Func, NULL, NULL);
     LOGI("Successfully initialized SDL hooks, stubs: %p, %p\n", stub_SDL_InitSubSystem);
 }

--- a/app_pojavlauncher/src/main/jni/native_hooks/sdl_hook.c
+++ b/app_pojavlauncher/src/main/jni/native_hooks/sdl_hook.c
@@ -35,8 +35,11 @@ static bool custom_SDL_InitSubSystem_Func(SDL_InitFlags flags) {
     // This is the normal for the launcher, the default in SDL is false.
     SET_DLSYM_PTR(dlopen("libSDL3.so", RTLD_NOLOAD), SDL_SetHint);
     if (SDL_SetHint_p) SDL_SetHint_p("SDL_RETURN_KEY_HIDES_IME", "true");
-    // FIXME: idk why it wont srgb, sorry
-    SDL_SetHint_p("SDL_OPENGL_FORCE_SRGB_FRAMEBUFFER", "0");
+    // FIXME: MobileGlues has issues with passing in the proper EGL params to make this work
+    const char *egl = getenv("POJAVEXEC_EGL");
+    if (egl && strcmp(egl, "libmobileglues.so") == 0) {
+        SDL_SetHint_p("SDL_OPENGL_FORCE_SRGB_FRAMEBUFFER", "0");
+    }
 
     // Call original func after doing all the needed setup
     bool r = BYTEHOOK_CALL_PREV(custom_SDL_InitSubSystem_Func, SDL_InitSubSystem_t, flags);

--- a/app_pojavlauncher/src/main/jni/native_hooks/sdl_hook.c
+++ b/app_pojavlauncher/src/main/jni/native_hooks/sdl_hook.c
@@ -19,7 +19,7 @@ DECL_DLSYM(SDL_SetError);
 static bool custom_SDL_InitSubSystem_Func(SDL_InitFlags flags) {
     // Call notifyLauncher on SDL_InitSubSystem, this sets up all the JNI stuff needed by SDL.
     TRY_ATTACH_ENV(dvm_env, pojav_environ->dalvikJavaVMPtr, "SDL_InitSubSystem failed!",
-            SET_DLSYM_PTR(SDL_SetError);
+            SET_DLSYM_PTR(dlopen("libSDL3.so", RTLD_NOLOAD), SDL_SetError);
             if (SDL_SetError_p) SDL_SetError_p("Failed to load SDL launcher integration android-side. This is not an SDL bug, please contact the launcher developer.");
             return false;
             );
@@ -33,7 +33,7 @@ static bool custom_SDL_InitSubSystem_Func(SDL_InitFlags flags) {
     notifyLauncher(dvm_env, NOTIF_TYPE_SDL, (int[]){ACTION_INIT_LAUNCHER_INTEGRATION, safeFlags}, 2);
 
     // This is the normal for the launcher, the default in SDL is false.
-    SET_DLSYM_PTR(SDL_SetHint);
+    SET_DLSYM_PTR(dlopen("libSDL3.so", RTLD_NOLOAD), SDL_SetHint);
     if (SDL_SetHint_p) SDL_SetHint_p("SDL_RETURN_KEY_HIDES_IME", "true");
     // FIXME: idk why it wont srgb, sorry
     SDL_SetHint_p("SDL_OPENGL_FORCE_SRGB_FRAMEBUFFER", "0");

--- a/app_pojavlauncher/src/main/jni/utils.h
+++ b/app_pojavlauncher/src/main/jni/utils.h
@@ -13,16 +13,17 @@
 
 #define DECL_DLSYM(fn) typedef typeof(&fn) fn##_t;
 
-#define SET_DLSYM_PTR(fn) \
-    fn##_t fn##_p;              \
-    do { \
-        dlerror(); \
-        void *_p = dlsym(RTLD_NEXT, #fn); \
-        const char *_e = dlerror(); \
-        if (_e || !_p) { \
-            LOGE("dlsym(%s) failed: %s\n", #fn, _e ? _e : "unknown error"); \
-        } \
-        fn##_p = (typeof(fn##_t))_p; \
+#define SET_DLSYM_PTR(handle, fn)                     \
+    fn##_t fn##_p;                                   \
+    do {                                             \
+        dlerror();                                   \
+        void *_p = dlsym((handle), #fn);             \
+        const char *_e = dlerror();                  \
+        if (_e || !_p) {                             \
+            LOGE("dlsym(%s) failed: %s\n",           \
+                 #fn, _e ? _e : "unknown error");    \
+        }                                            \
+        fn##_p = (fn##_t)_p;                         \
     } while (0)
 
 #define TRY_ATTACH_ENV(env_name, vm, error_message, then) JNIEnv* env_name;\


### PR DESCRIPTION
# Bugfixes
- SDL detection broke a bit, this caused controlify to stop working
- Fix setting the SDL error and hint sometimes causing crash
- Mitigation for MobileGlues color issue introduced by https://github.com/MobileGL-Dev/MobileGlues/pull/48
   - Should be removed when proper EGL handling is added