### PR TITLE
feat(TouchController): enable native bridge

### DIFF
--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -243,7 +243,7 @@ dependencies {
 
     // implementation 'net.sourceforge.streamsupport:streamsupport-cfuture:1.7.0'
 
-    implementation 'top.fifthlight.touchcontroller:proxy-client-android:0.0.4'
+    implementation 'top.fifthlight.touchcontroller:proxy-client-android:0.0.8'
 
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/TouchControllerUtils.java
@@ -102,11 +102,12 @@ public class TouchControllerUtils {
         }
         try {
             Os.setenv("TOUCH_CONTROLLER_PROXY_SOCKET", socketName, true);
+            Os.setenv("TOUCH_CONTROLLER_USE_NATIVE", "1", true);
         } catch (ErrnoException e) {
             Log.w("TouchController", "Failed to set TouchController environment variable", e);
         }
         MessageTransport transport = UnixSocketTransportKt.UnixSocketTransport(socketName);
-        proxyClient = new LauncherProxyClient(transport, Set.of(PlatformCapability.TEXT_STATUS, PlatformCapability.KEYBOARD_SHOW));
+        proxyClient = new LauncherProxyClient(transport, Set.of(PlatformCapability.TEXT_STATUS, PlatformCapability.KEYBOARD_SHOW), true);
         proxyClient.run();
         touchControllerInputView.setClient(proxyClient);
         Vibrator vibrator = ContextCompat.getSystemService(context, Vibrator.class);


### PR DESCRIPTION
Updated proxy to 0.0.6, and enabled native bridge.

The mod that supports native bridge is not released, but can be downloaded from GitHub Actions: https://github.com/TouchController/TouchController/actions/runs/30756528742