### PR TITLE
downgrade(bytehook): 1.1.2 to 1.0.10

### DIFF
--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -239,7 +239,7 @@ dependencies {
     // Our version of exp4j can be built from source at
     // https://github.com/PojavLauncherTeam/exp4j
     implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.6.1'
-    implementation 'com.bytedance:bytehook:1.1.2'
+    implementation 'com.bytedance:bytehook:1.0.10'
 
     // implementation 'net.sourceforge.streamsupport:streamsupport-cfuture:1.7.0'
 


### PR DESCRIPTION
It appears the hooks don't work properly on newer version (https://github.com/bytedance/bhook/issues/123)